### PR TITLE
Update the Call to get Permission for Async Flow

### DIFF
--- a/statelesshosting.py
+++ b/statelesshosting.py
@@ -224,8 +224,8 @@ def async():
     # The redirect_url is part of oAuth and where the user will be sent after consent. Appended to this URL will be the OAuth code or an error
     redirect_url = "http://" + _hosting_website + "/async_oauth_response?domain=" + domain + "&hosts=" + hosts + "&dns_provider=" + dns_provider
 
-    # Right now the call to get a permission requires the template in the path. Doesn't matter which one.  Spec is updating to eliminate this
-    asynchronousUrl = json_data['urlAsyncUX'] + '/v2/domainTemplates/providers/' + _provider + '/services/' + _template1 + '?' + \
+    # Call to get a permission
+    asynchronousUrl = json_data['urlAsyncUX'] + '/v2/domainTemplates/providers/' + _provider + '?' + \
             'domain=' + domain + \
             "&client_id=" + _provider + \
             "&scope=" + _template1 + ' ' + _template2 + \


### PR DESCRIPTION
As the Spec updated, there is no need for a template (service_id) to be passed in the uri as the templates are passed in the scope parameter