### PR TITLE
update for python:3.6

### DIFF
--- a/docker/Dockerfile-web
+++ b/docker/Dockerfile-web
@@ -1,10 +1,10 @@
 FROM python:3.6
 
-RUN pip3 install --upgrade pip3
+RUN python -m ensurepip --upgrade
 
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip install -r requirements.txt
 
-RUN pip3 install uwsgi
+RUN pip install uwsgi
 
 WORKDIR /workspace

--- a/sig.py
+++ b/sig.py
@@ -4,15 +4,15 @@
 
 from bottle import Bottle, run, route, template, request, response, abort, static_file, default_app, redirect
 
-import urllib
-#import urlparse
+from urllib.parse import urlparse
+from urllib.parse import unquote
 
 import util
 import sigutil
 import config
 
 @route('/sig', method='GET')
-def sig():    
+def sig():
 
     # This only works for the hosting website over the supported protocol
     if request.headers['Host'] != config.hosting_website or request.urlparts.scheme != config.protocol:
@@ -67,7 +67,7 @@ def sig_fetch():
                     'key': key,
                     'pubKey': pub_key,
                     'record_strings': record_strings
-                })                    
+                })
 
 
 @route('/sig_verify', method='POST')
@@ -112,7 +112,7 @@ def sig_verify():
                     'verified': verified,
                     'pubKey': pub,
                     'record_strings': record_strings
-                })                    
+                })
 
 @route('/sig_verify_url', method='POST')
 def sig_verify_url():
@@ -126,15 +126,15 @@ def sig_verify_url():
     domain = request.forms.get('domain')
 
     #params = urlparse.urlparse(url).query.split('&')
-    params = urllib.parse(url).query.split('&')
+    params = urlparse(url).query.split('&')
     sig = None
     key = None
     qs = None
     for param in params:
         if param.startswith('sig='):
-            sig = urllib.unquote(param[4:])
+            sig = unquote(param[4:])
         elif param.startswith('key='):
-            key = urllib.unquote(param[4:])
+            key = unquote(param[4:])
         else:
             if not qs:
                 qs = param
@@ -162,6 +162,6 @@ def sig_verify_url():
                     'verified': verified,
                     'pubKey': pub,
                     'record_strings': record_strings
-                })                    
+                })
 
 


### PR DESCRIPTION
### What does this PR do?
These are the changes I needed to make:
1) to get the exampleservice to run in docker with python 3.6
2) to fix the 500 error when calling <exampleservice>/sig_verify_url

### Why do we want to do that?
project was updated to python3.6 by https://github.com/Domain-Connect/exampleservice/commit/0046c677c4befeb6d83c14f8cfeeb9abd160fd6e

- docker version failed to run
  fixed by updating Dockerfile-web

- <exampleservice>/sig_verify_url was throwing a 500 error
  fixed by updating urllib imports in sig.py

### How did you test?
docker-compose build
docker-compose up
open http://exampleservice.domainconnect.local:8001/sig
manually enter values in form for "Verifying the Signature from the URL sent to the DNS Provider"