### PR TITLE
decode string for python3

### DIFF
--- a/util.py
+++ b/util.py
@@ -35,7 +35,7 @@ def get_messagetext(domain):
         answers = dns.resolver.query(domain, 'TXT')
         timestamps = {}
         for answer in answers:
-            data = answer.strings[0].split(':') # List containing ['shm', 'date', 'text']
+            data = answer.strings[0].decode("utf-8").split(':') # List containing ['shm', 'date', 'text']
             
             if data[0] == 'shm':
                 if len(data) == 2:


### PR DESCRIPTION
### What does this PR do?
fixes runtime error caused by changed types in python3

```
File "./exampleservice/util.py", line 38, in get_messagetext
    data = answer.strings[0].split(':') # List containing ['shm', 'date', 'text']
TypeError: a bytes-like object is required, not 'str'
```
type(answer.strings[0]) is <class 'bytes'> in python3 (sheesh)

```
Python 3.7.7 (default, Mar 10 2020, 15:43:03)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> str = 'string:1:2:3'
>>> a = str.split(':')
>>> a
['string', '1', '2', '3']
>>> str = b'string:1:2:3'
>>> a = str.split(':')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: a bytes-like object is required, not 'str'
>>>
```