### PR TITLE
Fix public key fetcher bug when the split public key has an "n" in the edges.

### DIFF
--- a/sigutil.py
+++ b/sigutil.py
@@ -81,7 +81,7 @@ def get_publickey(domain):
 
         # Concatenate all of the key segments
         for key in sorted(list(segments.keys())):
-            pembits = pembits + segments[key].strip('\n').strip('\\n').strip()
+            pembits = pembits + segments[key].replace('\n', '').replace('\\n', '').strip()
             
         return pembits, record_strings
     except:


### PR DESCRIPTION
Public keys may be split in more than one TXT record. For such cases, there's a chance that the letter "n" sits exactly at the beginning or at the end of some of the record strings, we cannot use python's strip('\\n') because it will take out the "n" and generate a wrong public key. Changed by replace('\\n', '') to avoid this issue.